### PR TITLE
fixes #10: Added --force push for mkdocs gh-deploy

### DIFF
--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -18,4 +18,4 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
- Previous build failed to push some refs to main repo due to commits mismatch in remote branch. Hence Added --force push for mkdocs gh-deploy
