### PR TITLE
feat: Add binary & test comparing output of Linux `perf` and `elastic/go-perf` library

### DIFF
--- a/cmd/cpi-count/.gitignore
+++ b/cmd/cpi-count/.gitignore
@@ -1,0 +1,1 @@
+cpi-count

--- a/cmd/cpi-count/go.mod
+++ b/cmd/cpi-count/go.mod
@@ -4,4 +4,10 @@ go 1.22.9
 
 require github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8
 
-require golang.org/x/sys v0.26.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/cmd/cpi-count/go.mod
+++ b/cmd/cpi-count/go.mod
@@ -2,7 +2,6 @@ module cpi-count
 
 go 1.22.9
 
-require (
-	github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8 // indirect
-	golang.org/x/sys v0.26.0 // indirect
-)
+require github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8
+
+require golang.org/x/sys v0.26.0 // indirect

--- a/cmd/cpi-count/go.mod
+++ b/cmd/cpi-count/go.mod
@@ -1,3 +1,8 @@
 module cpi-count
 
 go 1.22.9
+
+require (
+	github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+)

--- a/cmd/cpi-count/go.mod
+++ b/cmd/cpi-count/go.mod
@@ -1,0 +1,3 @@
+module cpi-count
+
+go 1.22.9

--- a/cmd/cpi-count/go.sum
+++ b/cmd/cpi-count/go.sum
@@ -1,0 +1,4 @@
+github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8 h1:FD01NjsTes0RxZVQ22ebNYJA4KDdInVnR9cn1hmaMwA=
+github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8/go.mod h1:Nt+pnRYvf0POC+7pXsrv8ubsEOSsaipJP0zlz1Ms1RM=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/cmd/cpi-count/go.sum
+++ b/cmd/cpi-count/go.sum
@@ -1,4 +1,13 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8 h1:FD01NjsTes0RxZVQ22ebNYJA4KDdInVnR9cn1hmaMwA=
 github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8/go.mod h1:Nt+pnRYvf0POC+7pXsrv8ubsEOSsaipJP0zlz1Ms1RM=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/cpi-count/goperf.go
+++ b/cmd/cpi-count/goperf.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"github.com/elastic/go-perf"
+)
+
+type GoPerf struct {
+	group      *perf.Group
+	event      *perf.Event
+	groupCount *perf.GroupCount
+
+	// This struct stores the output of the measured workload
+	// to prevent the compiler from optimizing the work away
+	workloadOutput string
+}
+
+func NewGoPerf() *GoPerf {
+	group := perf.Group{
+		CountFormat: perf.CountFormat{
+			Running: true,
+		},
+	}
+	group.Add(perf.Instructions, perf.CPUCycles)
+
+	goperf := GoPerf{
+		group: &group,
+	}
+
+	return &goperf
+}
+
+func (p *GoPerf) StartWorkloadMeasurement() error {
+	evt, err := p.group.Open(perf.CallingThread, perf.AnyCPU)
+	if err != nil {
+		return err
+	}
+	p.event = evt
+
+	gc, err := p.event.MeasureGroup(func() {
+		p.workloadOutput = heavyWorkload()
+	})
+
+	if err != nil {
+		return err
+	}
+
+	p.groupCount = &gc
+
+	return nil
+}
+
+func (p *GoPerf) End() (*PerfOutput, error) {
+	if err := p.event.Close(); err != nil {
+		return nil, err
+	}
+
+	return &PerfOutput{
+		Instrs: float64(p.groupCount.Values[0].Value),
+		Cycles: float64(p.groupCount.Values[1].Value),
+	}, nil
+}

--- a/cmd/cpi-count/goperf.go
+++ b/cmd/cpi-count/goperf.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+
 	"github.com/elastic/go-perf"
 )
 
@@ -58,4 +61,18 @@ func (p *GoPerf) End() (*PerfOutput, error) {
 		Instrs: float64(p.groupCount.Values[0].Value),
 		Cycles: float64(p.groupCount.Values[1].Value),
 	}, nil
+}
+
+func heavyWorkload() string {
+	seedStr := "1sAMsDJGtS3zNrK6MfeysFvUYOzlHqtj"
+
+	var hash string
+	hashBytes := sha256.Sum256([]byte(seedStr))
+
+	for i := 0; i < 999999; i++ {
+		hash = base64.StdEncoding.EncodeToString(hashBytes[:])
+		hashBytes = sha256.Sum256([]byte(hash))
+	}
+
+	return hash
 }

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("Hello, world!\n")
+}

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/elastic/go-perf"
 )
@@ -40,8 +39,6 @@ func main() {
 		log.Fatalf("Failed to execute perf cmd: %v\n", err)
 	}
 	log.Printf("Started perf cmd\n")
-
-	time.Sleep(100 * time.Millisecond)
 
 	var workloadOutput string
 	gc, err := p.MeasureGroup(func() {

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -1,14 +1,29 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
 	"log"
+	"os"
+	"os/exec"
 	"runtime"
+	"strconv"
+	"time"
 
 	"github.com/elastic/go-perf"
 )
 
 func main() {
-	g := perf.Group{}
+	pid := os.Getpid()
+	log.Printf("Current PID: %d\n", pid)
+
+	g := perf.Group{
+		CountFormat: perf.CountFormat{
+			Running: true,
+		},
+	}
 	g.Add(perf.Instructions, perf.CPUCycles)
 
 	runtime.LockOSThread()
@@ -23,6 +38,19 @@ func main() {
 		p.Close()
 	}()
 
+	var perfOutputBuf bytes.Buffer
+
+	perfCmd := exec.Command("perf", "stat", "-j", "-e", "instructions,cycles", "-p", strconv.Itoa(pid))
+	perfCmd.Stdout = &perfOutputBuf
+	perfCmd.Stderr = &perfOutputBuf
+
+	if err := perfCmd.Start(); err != nil {
+		log.Fatalf("Failed to execute perf cmd\n")
+	}
+	log.Printf("Started perf cmd\n")
+
+	time.Sleep(100 * time.Millisecond)
+
 	sum := float64(0)
 	gc, err := p.MeasureGroup(func() {
 		heavy_workload(&sum)
@@ -34,12 +62,63 @@ func main() {
 
 	cycles, instrs := gc.Values[1].Value, gc.Values[0].Value
 	log.Printf("Sum is %f\n", sum)
-	log.Printf("Ran for %vns\n", gc.Running.Nanoseconds())
+	log.Printf("Ran for %dms\n", gc.Running.Milliseconds())
 	log.Printf("Cycles: %d, Instrs: %d, CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
+
+	if err := perfCmd.Process.Signal(os.Interrupt); err != nil {
+		log.Fatalf("Failed to send SIGINT to perf: %v\n", err)
+	}
+
+	if err := perfCmd.Wait(); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			log.Fatalf("Error waiting for perf cmd: %v\n", err)
+		}
+	}
+
+	perfCmdCycles, perfCmdInstrs := parsePerfCmdOutput(&perfOutputBuf)
+	log.Printf("PerfCmd Cycles: %d, PerfCmd Instrs: %d, PerfCmd CPI: %f\n", int64(perfCmdCycles), int64(perfCmdInstrs), perfCmdCycles/perfCmdInstrs)
 }
 
 func heavy_workload(sum *float64) {
-	for i := 0; i < 1000000; i++ {
+	for i := 0; i < 10000000; i++ {
 		*sum += float64(i)
 	}
+}
+
+func parsePerfCmdOutput(output io.Reader) (float64, float64) {
+	type PerfCounterOutput struct {
+		Event string `json:"event"`
+		Count string `json:"counter-value"`
+	}
+
+	scanner := bufio.NewScanner(output)
+	var instrs, cycles float64
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		var data PerfCounterOutput
+		err := json.Unmarshal([]byte(line), &data)
+		if err != nil {
+			log.Fatalf("Failed to parse perf cmd output: %s\n", line)
+		}
+
+		count, err := strconv.ParseFloat(data.Count, 64)
+
+		if err != nil {
+			log.Fatalf("Failed to parse perf cmd counter value: %s\n", data.Count)
+		}
+
+		switch data.Event {
+		case "instructions":
+			instrs = count
+		case "cycles":
+			cycles = count
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Failed to scan perf cmd output\n")
+	}
+
+	return cycles, instrs
 }

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -28,10 +28,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to open perf events: %s\n", err)
 	}
-	defer func() {
-		log.Printf("Finished running, closing event group.\n")
-		p.Close()
-	}()
 
 	perfCmd := NewPerfCmd(pid)
 
@@ -49,6 +45,7 @@ func main() {
 		log.Fatalf("Failed to measure perf group: %s\n", err)
 	}
 
+	p.Close()
 	perfOutput, err := perfCmd.End()
 	if err != nil {
 		log.Fatalf("Failed to end perf cmd: %v\n", err)

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -23,11 +23,9 @@ func main() {
 		p.Close()
 	}()
 
-	sum := 0
+	sum := float64(0)
 	gc, err := p.MeasureGroup(func() {
-		for i := 0; i < 10000; i++ {
-			sum += i
-		}
+		heavy_workload(&sum)
 	})
 
 	if err != nil {
@@ -35,6 +33,13 @@ func main() {
 	}
 
 	cycles, instrs := gc.Values[1].Value, gc.Values[0].Value
-	log.Printf("Ran for %vms\n", gc.Running.Milliseconds())
+	log.Printf("Sum is %f\n", sum)
+	log.Printf("Ran for %vns\n", gc.Running.Nanoseconds())
 	log.Printf("Cycles: %d, Instrs: %d, CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
+}
+
+func heavy_workload(sum *float64) {
+	for i := 0; i < 1000000; i++ {
+		*sum += float64(i)
+	}
 }

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	sum := float64(0)
 	gc, err := p.MeasureGroup(func() {
-		heavy_workload(&sum)
+		heavyWorkload(&sum)
 	})
 
 	if err != nil {
@@ -63,7 +63,7 @@ func main() {
 	cycles, instrs := gc.Values[1].Value, gc.Values[0].Value
 	log.Printf("Sum is %f\n", sum)
 	log.Printf("Ran for %dms\n", gc.Running.Milliseconds())
-	log.Printf("Cycles: %d, Instrs: %d, CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
+	log.Printf("GoPerf Cycles: %d, GoPerf Instrs: %d, GoPerf CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
 
 	if err := perfCmd.Process.Signal(os.Interrupt); err != nil {
 		log.Fatalf("Failed to send SIGINT to perf: %v\n", err)
@@ -79,7 +79,7 @@ func main() {
 	log.Printf("PerfCmd Cycles: %d, PerfCmd Instrs: %d, PerfCmd CPI: %f\n", int64(perfCmdCycles), int64(perfCmdInstrs), perfCmdCycles/perfCmdInstrs)
 }
 
-func heavy_workload(sum *float64) {
+func heavyWorkload(sum *float64) {
 	for i := 0; i < 10000000; i++ {
 		*sum += float64(i)
 	}

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"os"
 	"runtime"
 )
 
@@ -17,7 +16,7 @@ func init() {
 }
 
 func main() {
-	perfCmd := NewPerfCmd(os.Getpid())
+	perfCmd := NewPerfCmd()
 	if err := perfCmd.Start(); err != nil {
 		log.Fatalf("Failed to execute perf cmd: %v\n", err)
 	}

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -28,8 +28,8 @@ func main() {
 	if err := perfCmd.Start(); err != nil {
 		log.Fatalf("Failed to execute perf cmd: %v\n", err)
 	}
-
 	log.Printf("Started perf cmd\n")
+
 	g := perf.Group{
 		CountFormat: perf.CountFormat{
 			Running: true,

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -57,11 +57,11 @@ func main() {
 	log.Printf("Ran for %dms\n", gc.Running.Milliseconds())
 	log.Printf("GoPerf Cycles: %d, GoPerf Instrs: %d, GoPerf CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
 
-	if err := perfCmd.End(); err != nil {
+	perfOutput, err := perfCmd.End()
+	if err != nil {
 		log.Fatalf("Failed to end perf cmd: %v\n", err)
 	}
 
-	perfOutput := perfCmd.Output()
 	log.Printf("PerfCmd Cycles: %d, PerfCmd Instrs: %d, PerfCmd CPI: %f\n", int64(perfOutput.Cycles), int64(perfOutput.Instrs), perfOutput.Cycles/perfOutput.Instrs)
 }
 

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -36,6 +36,6 @@ func main() {
 		log.Fatalf("Failed to end perf cmd: %v\n", err)
 	}
 
-	log.Printf("GoPerf Cycles: %d, GoPerf Instrs: %d, GoPerf CPI: %f\n", int64(goperfOutput.Cycles), int64(goperfOutput.Instrs), goperfOutput.Cycles/goperfOutput.Instrs)
-	log.Printf("PerfCmd Cycles: %d, PerfCmd Instrs: %d, PerfCmd CPI: %f\n", int64(perfOutput.Cycles), int64(perfOutput.Instrs), perfOutput.Cycles/perfOutput.Instrs)
+	log.Printf("GoPerf Cycles: %d, GoPerf Instrs: %d, GoPerf CPI: %f\n", int64(goperfOutput.Cycles), int64(goperfOutput.Instrs), goperfOutput.CPI())
+	log.Printf("PerfCmd Cycles: %d, PerfCmd Instrs: %d, PerfCmd CPI: %f\n", int64(perfOutput.Cycles), int64(perfOutput.Instrs), perfOutput.CPI())
 }

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -52,16 +52,15 @@ func main() {
 		log.Fatalf("Failed to measure perf group: %s\n", err)
 	}
 
-	cycles, instrs := gc.Values[1].Value, gc.Values[0].Value
-	log.Printf("Output is %s\n", workloadOutput)
-	log.Printf("Ran for %dms\n", gc.Running.Milliseconds())
-	log.Printf("GoPerf Cycles: %d, GoPerf Instrs: %d, GoPerf CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
-
 	perfOutput, err := perfCmd.End()
 	if err != nil {
 		log.Fatalf("Failed to end perf cmd: %v\n", err)
 	}
 
+	cycles, instrs := gc.Values[1].Value, gc.Values[0].Value
+	log.Printf("Output is %s\n", workloadOutput)
+	log.Printf("Ran for %dms\n", gc.Running.Milliseconds())
+	log.Printf("GoPerf Cycles: %d, GoPerf Instrs: %d, GoPerf CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
 	log.Printf("PerfCmd Cycles: %d, PerfCmd Instrs: %d, PerfCmd CPI: %f\n", int64(perfOutput.Cycles), int64(perfOutput.Instrs), perfOutput.Cycles/perfOutput.Instrs)
 }
 

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -1,7 +1,40 @@
 package main
 
-import "fmt"
+import (
+	"log"
+	"runtime"
+
+	"github.com/elastic/go-perf"
+)
 
 func main() {
-	fmt.Printf("Hello, world!\n")
+	g := perf.Group{}
+	g.Add(perf.Instructions, perf.CPUCycles)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	p, err := g.Open(perf.CallingThread, perf.AnyCPU)
+	if err != nil {
+		log.Fatalf("Failed to open perf events: %s\n", err)
+	}
+	defer func() {
+		log.Printf("Finished running, closing event group.\n")
+		p.Close()
+	}()
+
+	sum := 0
+	gc, err := p.MeasureGroup(func() {
+		for i := 0; i < 10000; i++ {
+			sum += i
+		}
+	})
+
+	if err != nil {
+		log.Fatalf("Failed to measure perf group: %s\n", err)
+	}
+
+	cycles, instrs := gc.Values[1].Value, gc.Values[0].Value
+	log.Printf("Ran for %vms\n", gc.Running.Milliseconds())
+	log.Printf("Cycles: %d, Instrs: %d, CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
 }

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -24,6 +24,12 @@ func main() {
 	pid := os.Getpid()
 	log.Printf("Current PID: %d\n", pid)
 
+	perfCmd := NewPerfCmd(pid)
+	if err := perfCmd.Start(); err != nil {
+		log.Fatalf("Failed to execute perf cmd: %v\n", err)
+	}
+
+	log.Printf("Started perf cmd\n")
 	g := perf.Group{
 		CountFormat: perf.CountFormat{
 			Running: true,
@@ -35,13 +41,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to open perf events: %s\n", err)
 	}
-
-	perfCmd := NewPerfCmd(pid)
-
-	if err := perfCmd.Start(); err != nil {
-		log.Fatalf("Failed to execute perf cmd: %v\n", err)
-	}
-	log.Printf("Started perf cmd\n")
 
 	var workloadOutput string
 	gc, err := p.MeasureGroup(func() {

--- a/cmd/cpi-count/main.go
+++ b/cmd/cpi-count/main.go
@@ -1,13 +1,9 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
 	"log"
 	"os"
 	"runtime"
-
-	"github.com/elastic/go-perf"
 )
 
 func init() {
@@ -21,59 +17,26 @@ func init() {
 }
 
 func main() {
-	pid := os.Getpid()
-	log.Printf("Current PID: %d\n", pid)
-
-	perfCmd := NewPerfCmd(pid)
+	perfCmd := NewPerfCmd(os.Getpid())
 	if err := perfCmd.Start(); err != nil {
 		log.Fatalf("Failed to execute perf cmd: %v\n", err)
 	}
-	log.Printf("Started perf cmd\n")
 
-	g := perf.Group{
-		CountFormat: perf.CountFormat{
-			Running: true,
-		},
+	goperf := NewGoPerf()
+	if err := goperf.StartWorkloadMeasurement(); err != nil {
+		log.Fatalf("Failed to start goperf measurement: %v\n", err)
 	}
-	g.Add(perf.Instructions, perf.CPUCycles)
 
-	p, err := g.Open(perf.CallingThread, perf.AnyCPU)
+	goperfOutput, err := goperf.End()
 	if err != nil {
-		log.Fatalf("Failed to open perf events: %s\n", err)
+		log.Fatalf("Failed to end goperf measurement: %v\n", err)
 	}
 
-	var workloadOutput string
-	gc, err := p.MeasureGroup(func() {
-		workloadOutput = heavyWorkload()
-	})
-
-	if err != nil {
-		log.Fatalf("Failed to measure perf group: %s\n", err)
-	}
-
-	p.Close()
 	perfOutput, err := perfCmd.End()
 	if err != nil {
 		log.Fatalf("Failed to end perf cmd: %v\n", err)
 	}
 
-	cycles, instrs := gc.Values[1].Value, gc.Values[0].Value
-	log.Printf("Output is %s\n", workloadOutput)
-	log.Printf("Ran for %dms\n", gc.Running.Milliseconds())
-	log.Printf("GoPerf Cycles: %d, GoPerf Instrs: %d, GoPerf CPI: %f\n", cycles, instrs, float64(cycles)/float64(instrs))
+	log.Printf("GoPerf Cycles: %d, GoPerf Instrs: %d, GoPerf CPI: %f\n", int64(goperfOutput.Cycles), int64(goperfOutput.Instrs), goperfOutput.Cycles/goperfOutput.Instrs)
 	log.Printf("PerfCmd Cycles: %d, PerfCmd Instrs: %d, PerfCmd CPI: %f\n", int64(perfOutput.Cycles), int64(perfOutput.Instrs), perfOutput.Cycles/perfOutput.Instrs)
-}
-
-func heavyWorkload() string {
-	seedStr := "1sAMsDJGtS3zNrK6MfeysFvUYOzlHqtj"
-
-	var hash string
-	hashBytes := sha256.Sum256([]byte(seedStr))
-
-	for i := 0; i < 999999; i++ {
-		hash = base64.StdEncoding.EncodeToString(hashBytes[:])
-		hashBytes = sha256.Sum256([]byte(hash))
-	}
-
-	return hash
 }

--- a/cmd/cpi-count/perf.go
+++ b/cmd/cpi-count/perf.go
@@ -15,10 +15,10 @@ type PerfCmd struct {
 	output *bytes.Buffer
 }
 
-func NewPerfCmd(pid int) *PerfCmd {
+func NewPerfCmd() *PerfCmd {
 	var buf bytes.Buffer
 
-	cmd := exec.Command("perf", "stat", "-j", "-e", "instructions,cycles", "-p", strconv.Itoa(pid))
+	cmd := exec.Command("perf", "stat", "-j", "-e", "instructions,cycles", "-p", strconv.Itoa(os.Getpid()))
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
 

--- a/cmd/cpi-count/perf.go
+++ b/cmd/cpi-count/perf.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log"
+	"strconv"
+)
+
+type perfOutput struct {
+	Event string `json:"event"`
+	Count string `json:"counter-value"`
+}
+
+type perfOutputCollated struct {
+	Instrs float64
+	Cycles float64
+}
+
+func parsePerfCmdOutput(output io.Reader) perfOutputCollated {
+	scanner := bufio.NewScanner(output)
+	var out perfOutputCollated
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		var data perfOutput
+		err := json.Unmarshal([]byte(line), &data)
+		if err != nil {
+			log.Fatalf("Failed to parse perf cmd output: %s\n", line)
+		}
+
+		count, err := strconv.ParseFloat(data.Count, 64)
+
+		if err != nil {
+			log.Fatalf("Failed to parse perf cmd counter value: %s\n", data.Count)
+		}
+
+		switch data.Event {
+		case "instructions":
+			out.Instrs = count
+		case "cycles":
+			out.Cycles = count
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Failed to scan perf cmd output\n")
+	}
+
+	return out
+}

--- a/cmd/cpi-count/perf.go
+++ b/cmd/cpi-count/perf.go
@@ -32,7 +32,7 @@ func (p *PerfCmd) Start() error {
 	return p.cmd.Start()
 }
 
-func (p *PerfCmd) End() (*PerfOutputCollated, error) {
+func (p *PerfCmd) End() (*PerfOutput, error) {
 	// Send Ctrl-C to the perf process...
 	if err := p.cmd.Process.Signal(os.Interrupt); err != nil {
 		return nil, err
@@ -58,14 +58,14 @@ type perfOutput struct {
 	Count string `json:"counter-value"`
 }
 
-type PerfOutputCollated struct {
+type PerfOutput struct {
 	Instrs float64
 	Cycles float64
 }
 
-func parsePerfCmdOutput(output io.Reader) (*PerfOutputCollated, error) {
+func parsePerfCmdOutput(output io.Reader) (*PerfOutput, error) {
 	scanner := bufio.NewScanner(output)
-	var out PerfOutputCollated
+	var out PerfOutput
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/cmd/cpi-count/perf.go
+++ b/cmd/cpi-count/perf.go
@@ -13,7 +13,7 @@ import (
 
 type PerfCmd struct {
 	cmd    *exec.Cmd
-	output bytes.Buffer
+	output *bytes.Buffer
 }
 
 func NewPerfCmd(pid int) *PerfCmd {
@@ -25,7 +25,7 @@ func NewPerfCmd(pid int) *PerfCmd {
 
 	return &PerfCmd{
 		cmd:    cmd,
-		output: buf,
+		output: &buf,
 	}
 }
 
@@ -50,7 +50,7 @@ func (p *PerfCmd) End() error {
 }
 
 func (p *PerfCmd) Output() PerfOutputCollated {
-	return parsePerfCmdOutput(&p.output)
+	return parsePerfCmdOutput(p.output)
 }
 
 type perfOutput struct {

--- a/cmd/cpi-count/perf.go
+++ b/cmd/cpi-count/perf.go
@@ -63,6 +63,10 @@ type PerfOutput struct {
 	Cycles float64
 }
 
+func (p *PerfOutput) CPI() float64 {
+	return p.Cycles / p.Instrs
+}
+
 func parsePerfCmdOutput(output io.Reader) (*PerfOutput, error) {
 	scanner := bufio.NewScanner(output)
 	var out PerfOutput

--- a/cmd/cpi-count/perf_test.go
+++ b/cmd/cpi-count/perf_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoPerfVsPerfCmd(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	perfCmd := NewPerfCmd()
+	err := perfCmd.Start()
+
+	goperf := NewGoPerf()
+	err = goperf.StartWorkloadMeasurement()
+	require.NoError(t, err)
+
+	goperfOutput, err := goperf.End()
+	require.NoError(t, err)
+
+	perfOutput, err := perfCmd.End()
+	require.NoError(t, err)
+
+	require.InEpsilon(t, goperfOutput.Cycles, perfOutput.Cycles, 0.15)
+	require.InEpsilon(t, goperfOutput.Instrs, perfOutput.Instrs, 0.15)
+	require.InEpsilon(t, goperfOutput.CPI(), perfOutput.CPI(), 0.08)
+}


### PR DESCRIPTION
This patch addresses #23 .

It adds a new binary, `cpi-count`, that measures an artificial CPU-bound workload using two methods:
- Linux `perf`
- `elastic/go-perf` library

When run, the binary prints out the measured cycles, instructions, and CPI, using both methods:
```bash
$ go build . && sudo ./cpi-count
2024/12/25 13:26:10 GoPerf Cycles: 523916886, GoPerf Instrs: 2040367688, GoPerf CPI: 0.256776
2024/12/25 13:26:10 PerfCmd Cycles: 560685244, PerfCmd Instrs: 2094182633, PerfCmd CPI: 0.267735
```

The program is arranged in a simple, symmetric manner:
- Start measurement `perf`
- Start workload and measurement using `go-perf`
- Stop `go-perf` measurement
- Stop `perf` measurement.

A test is also provided that asserts that the measured cycles, instructions, and CPI are similar across both measurement methods. For the raw cycle and instruction counts, we assert that the values are within 15% across the methods. For CPI, we assert that the values are within 8% across the methods.

Both the program and the test require elevated privileges (ie, `sudo`) to run, at least on my machine.

One interesting  finding is that if `runtime.LockOsThread` is not invoked prior to launching the measurements,  Linux `perf` seems to report ~4x the cycles and instructions on my machine, compared to measurements produced by `go-perf`. Funnily enough, CPI is relatively unaffected since both cycles and instructions are proportionally inflated. Still, we ensure that `runtime.LockOsThread` is invoked, both in the binary, as well as the provided test.

Note: #23 calls for a Github action that can run the test, but I'd like to do that as a follow-on, if that's alright
