### PR TITLE
Disable unnecessary(?) sleep in integration test

### DIFF
--- a/cmd/collector/collector_test.go
+++ b/cmd/collector/collector_test.go
@@ -15,7 +15,7 @@ func TestMetricsUp(t *testing.T) {
 
 	// Initialize module/server for standalone integration test
 	go main()
-	time.Sleep(1 * time.Second)
+	// time.Sleep(1 * time.Second)
 
 	// Set values for standalone integration test
 	serverURL := "http://localhost:2112"


### PR DESCRIPTION
Addendum to PR #27, comments out a sleep call to reduce integration test time to complete by 10x / 1s but remain present as a reminder in case something related to initialization time breaks