### PR TITLE
Memory Collector CI Modifications

### DIFF
--- a/.github/workflows/ci-collector.yaml
+++ b/.github/workflows/ci-collector.yaml
@@ -5,20 +5,21 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feature-mem-collector-ci
+      - main
     paths:
-      - 'cmd/**'
+      - 'cmd/collector/**'
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ vars.DOCKERHUB_USERNAME }} # Need to be set as Github variable in the repository.
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }} # Need to be set as Github secret in the repository.
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -29,7 +30,7 @@ jobs:
         id: docker-metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.container-repo }}
+          images: ghcr.io/${{ github.repository }}/collector
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
@@ -37,13 +38,12 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          # push: ${{ github.event_name != 'pull_request' }}
-          push: false
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}
           context: cmd/collector
           file: cmd/collector/Dockerfile
           platforms: linux/amd64,linux/arm64
-        #   cache-from: type=registry,ref=<Placeholder>:cache # Need to add the repository name
-        #   cache-to: type=registry,image-manifest=true,oci-mediatypes=true,ref=<Placeholder>:cache,mode=max # Need to add the repository name
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/collector:cache
+          cache-to: type=registry,image-manifest=true,oci-mediatypes=true,ref=ghcr.io/${{ github.repository }}/collector:cache,mode=max
         

--- a/.github/workflows/ci-cpi-count.yaml
+++ b/.github/workflows/ci-cpi-count.yaml
@@ -5,20 +5,21 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feature-mem-collector-ci
+      - main
     paths:
-      - 'cmd/**'
+      - 'cmd/cpi-count/**'
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ vars.DOCKERHUB_USERNAME }} # Need to be set as Github variable in the repository.
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }} # Need to be set as Github secret in the repository.
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -29,7 +30,7 @@ jobs:
         id: docker-metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.container-repo }}
+          images: ghcr.io/${{ github.repository }}/cpi-count
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
@@ -37,15 +38,14 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-        #   push: ${{ github.event_name != 'pull_request' }}
-          push: false
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}
           context: cmd/cpi-count
           file: cmd/cpi-count/Dockerfile
           platforms: linux/amd64,linux/arm64
-        #   cache-from: type=registry,ref=<Placeholder>:cache # Need to add the repository name
-        #   cache-to: type=registry,image-manifest=true,oci-mediatypes=true,ref=<Placeholder>:cache,mode=max # Need to add the repository name
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cpi-count:cache # Need to add the repository name
+          cache-to: type=registry,image-manifest=true,oci-mediatypes=true,ref=ghcr.io/${{ github.repository }}/cpi-count:cache,mode=max # Need to add the repository name
         
         
         


### PR DESCRIPTION
Memory Collector CI Modifications:
1. Added the GHCR repo name --> `<repository_name>/<container_image_name>` --> In our case: `ghcr.io/memory-collector/cpi-count` and `ghcr.io/memory-collector/collector`.
2. Authentication to **GHCR** instead of **DockerHub**.
3. Fixed the push to my side-branch to the actual `main`, my bad sorry about that.
4. Also added **docker build cache** so the build would take less and get some of the layers at least from cache and not rebuild them from scratch each time.

These changes should ensure the images would be build into GHCR of this project respectively.