### PR TITLE
Add GitHub Action for Prometheus Integration Test

### DIFF
--- a/.github/workflows/Prometheus Integration Test.yml
+++ b/.github/workflows/Prometheus Integration Test.yml
@@ -1,0 +1,29 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Prometheus Integration Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22.9'
+
+    # - name: Build
+    #   run: go build -v ./cmd/collector/
+
+    - name: Test
+      working-directory: ./cmd/collector/
+      run: go test -v


### PR DESCRIPTION
Resolves #21. This worked on my fork, but review and/or testing is welcome to confirm whether it properly returns the test pass and fail cases, particularly after setting up Go and compiling correctly.